### PR TITLE
Fix for null string in upload directory

### DIFF
--- a/src/libs/DirectoryPicker.js
+++ b/src/libs/DirectoryPicker.js
@@ -39,6 +39,8 @@ class DirectoryPicker extends FilePicker {
 
   // parses the string back to something the FilePicker can understand as an option
   static parse(str) {
+    if (str === null)
+      str = "";
     let matches = str.match(/\[(.+)\]\s*(.+)/);
     if (matches) {
       let source = matches[1];


### PR DESCRIPTION
If users set the upload directory and then remove it to revert back to default behaviour, a null object is passed into the parse method. This commit simply checks for the null and uses an empty string if it is detected, thus reverting the behaviour back to default (save to Data directory).

This will address https://github.com/MrPrimate/vtta-tokenizer/issues/2 and https://github.com/MrPrimate/vtta-tokenizer/issues/4