### PR TITLE
Translucent overlays

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -7,7 +7,11 @@
   "vtta-tokenizer.image-upload-directory.hint": "The avatar and token upload location on the server, relative to the Foundry /Data directory, e.g. 'img/uploads' is '[Foundry]/Data/img/uploads'.",
   "vtta-tokenizer.npc-image-upload-directory.name": "NPC image upload directory for NPC tokens",
   "vtta-tokenizer.npc-image-upload-directory.hint": "The avatar and token upload location on the server, relative to the Foundry /Data directory, e.g. 'img/uploads' is '[Foundry]/Data/img/uploads'.",
+  "vtta-tokenizer.image-save-type.name": "Image File Type",
+  "vtta-tokenizer.image-save-type.hint": "The avatar and token images will be saved in this format. webp is preferred as it produces smaller file sizes on average.",
   "vtta-tokenizer.token-size.name": "Token size",
   "vtta-tokenizer.token-size.hint": "Specifies the token size (width and height). A value higher than 200 is recommended.",
+  "vtta-tokenizer.portrait-size.name": "Portrait size",
+  "vtta-tokenizer.portrait-size.hint": "Specifies the portrait size (width and height). A value higher than 200 is recommended.",
   "vtta-tokenizer.requires-upload-permission": "Tokenizer requires the permission to Upload Files. Please inform your Gamemaster."
 }

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -42,9 +42,28 @@ export function init() {
     default: "",
   });
 
+  game.settings.register("vtta-tokenizer", "image-save-type", {
+    name: "vtta-tokenizer.image-save-type.name",
+    hint: "vtta-tokenizer.image-save-type.hint",
+    scope: "world",
+    config: true,
+    default: "webp",
+    choices: { "webp": "*.webp", "png": "*.png" },
+    type: String,
+  });
+
   game.settings.register("vtta-tokenizer", "token-size", {
     name: "vtta-tokenizer.token-size.name",
     hint: "vtta-tokenizer.token-size.hint",
+    scope: "world",
+    config: true,
+    type: Number,
+    default: 400,
+  });
+
+  game.settings.register("vtta-tokenizer", "portrait-size", {
+    name: "vtta-tokenizer.portrait-size.name",
+    hint: "vtta-tokenizer.portrait-size.hint",
     scope: "world",
     config: true,
     type: Number,

--- a/src/tokenizer/index.js
+++ b/src/tokenizer/index.js
@@ -32,6 +32,7 @@ export default class Tokenizer extends FormApplication {
   async _getFilename(suffix = "Avatar") {
     const isWildCard = () => this.actor.data.token.randomImg;
     const actorName = Utils.makeSlug(this.actor.name);
+    const imageFormat = game.settings.get("vtta-tokenizer", "image-save-type");
 
     if (suffix === "Token" && isWildCard()) {
       const options = DirectoryPicker.parse(Utils.getBaseUploadFolder(this.actor.data.type));
@@ -40,7 +41,7 @@ export default class Tokenizer extends FormApplication {
 
       if (tokenWildcard.indexOf("*") === -1) {
         // set it to a wildcard we can actually use
-        tokenWildcard = `${options.current}/${actorName}.Token-*.png`;
+        tokenWildcard = `${options.current}/${actorName}.Token-*.${imageFormat}`;
       }
       // get the next free index
       const browser = await FilePicker.browse(options.activeSource, tokenWildcard, {
@@ -56,12 +57,14 @@ export default class Tokenizer extends FormApplication {
 
       return targetFilename;
     }
-    return `${actorName}.${suffix}.png`;
+    return `${actorName}.${suffix}.${imageFormat}`;
   }
 
   _updateObject(event, formData) {
     // Update the object this ApplicationForm is based on
     // e.g. this.object.update(formData)
+
+    const imageFormat = game.settings.get("vtta-tokenizer", "image-save-type");
 
     // upload token and avatar
     let avatarFilename = formData.targetAvatarFilename;
@@ -86,7 +89,7 @@ export default class Tokenizer extends FormApplication {
           // set it to a wildcard we can actually use
           ui.notifications.info("Tokenizer: Wildcarding token image to " + this.actor.data.token.img);
           update.token = {
-            img: `${options.current}/${actorName}.Token-*.png`,
+            img: `${options.current}/${actorName}.Token-*.${imageFormat}`,
           };
         }
       } else {
@@ -113,8 +116,8 @@ export default class Tokenizer extends FormApplication {
     this.Avatar = null
     try {
       const img = await Utils.download(url)
-      const MAX_DIMENSION = Math.max(img.naturalHeight, img.naturalWidth);
-      console.log("Setting Avatar dimensions to " + MAX_DIMENSION + "/" + MAX_DIMENSION);
+      const MAX_DIMENSION = Math.max(img.naturalHeight, img.naturalWidth, game.settings.get("vtta-tokenizer", "portrait-size"));
+      console.log("Setting Avatar dimensions to " + MAX_DIMENSION + "x" + MAX_DIMENSION);
       this.Avatar = new View(MAX_DIMENSION, avatarView);
       this.Avatar.addImageLayer(img);
 

--- a/src/tokenizer/layer.js
+++ b/src/tokenizer/layer.js
@@ -79,7 +79,7 @@ export default class Layer {
     let ctx = temp.getContext('2d');
     let pixels = ctx.getImageData(0, 0, this.source.width + 2, this.source.height + 2);
 
-    const transparencyThreshold = 50;
+    const transparencyThreshold = 254;
 
     let completelyTransparent = () => {
       let pixels = this.source.getContext('2d').getImageData(0, 0, this.source.width, this.source.height).data;

--- a/src/tokenizer/view.js
+++ b/src/tokenizer/view.js
@@ -79,9 +79,9 @@ export default class View {
         return new Promise((resolve, reject) => {
           try {
             this.canvas.toBlob(blob => {
-              resolve(blob);
-            },
-            `image/${imageFormat}`);
+                  resolve(blob);
+                },
+                `image/${imageFormat}`);
           } catch (error) {
             reject(error);
           }
@@ -472,20 +472,21 @@ export default class View {
   }
 
   redraw() {
+    let maskLayer = undefined
     let ctx = this.canvas.getContext('2d');
     ctx.clearRect(0, 0, this.width, this.height);
 
     if (this.maskId !== null) {
       // get the mask layer
-      let maskLayer = this.layers.find(layer => layer.id === this.maskId);
+      maskLayer = this.layers.find(layer => layer.id === this.maskId);
       // draw the mask at the same position and scale as the source of the layer itself
       ctx.globalCompositeOperation = 'source-over';
       ctx.drawImage(
-        maskLayer.sourceMask,
-        maskLayer.position.x,
-        maskLayer.position.y,
-        maskLayer.source.width * maskLayer.scale,
-        maskLayer.source.height * maskLayer.scale
+          maskLayer.sourceMask,
+          maskLayer.position.x,
+          maskLayer.position.y,
+          maskLayer.source.width * maskLayer.scale,
+          maskLayer.source.height * maskLayer.scale
       );
 
       ctx.globalCompositeOperation = 'source-atop';
@@ -495,6 +496,15 @@ export default class View {
     // draw all the layers on top of each other
     for (let i = this.layers.length - 1; i >= 0; i--) {
       ctx.drawImage(this.layers[i].view, 0, 0, this.width, this.height);
+    }
+
+    // draw the mask again on top as clipping may have happened to semi-transparent pixels
+    // but only if defined as the top layer
+    if (maskLayer !== undefined) {
+      if(this.layers[0].id == maskLayer.id) {
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.drawImage(maskLayer.view, 0, 0, this.width, this.height);
+      }
     }
   }
 }

--- a/src/tokenizer/view.js
+++ b/src/tokenizer/view.js
@@ -75,11 +75,13 @@ export default class View {
           img.src = this.canvas.toDataURL();
         });
       case 'blob':
+        const imageFormat = game.settings.get("vtta-tokenizer", "image-save-type");
         return new Promise((resolve, reject) => {
           try {
             this.canvas.toBlob(blob => {
               resolve(blob);
-            });
+            },
+            `image/${imageFormat}`);
           } catch (error) {
             reject(error);
           }


### PR DESCRIPTION
This change basically redraws the "mask" layer if it's the top layer and sets the pixel check for borders to be only pixels with no alpha channel, i.e. transparency.

So instead of getting a token that looks like this:
![image](https://user-images.githubusercontent.com/8051654/118379813-19ad0c00-b5a3-11eb-9ef4-e8842585813e.png)

You get this:
![image](https://user-images.githubusercontent.com/8051654/118379833-3d705200-b5a3-11eb-863d-03a1f6f95e09.png)
