### PR TITLE
Feature/launch tokenizer without token (still needs an actor.name for the filenames)

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -114,12 +114,12 @@ export function init() {
   });
 }
 
-function launchTokenizer(actor) {
+function launchTokenizer(actor, callback) {
   if (!game.user.can("FILES_UPLOAD")) {
     ui.notifications.warn(game.i18n.localize("vtta-tokenizer.requires-upload-permission"));
   }
 
-  const tokenizer = new Tokenizer({}, actor);
+  const tokenizer = new Tokenizer({}, actor, callback);
   tokenizer.render(true);
 
 }


### PR DESCRIPTION
Example usage:

JavaScript
```js
window.Tokenizer.launch({ name: 'actorName' }, (response) => {
    console.log(response.avatarFilename);
    console.log(response.tokenFilename);
});
```

TypeScript
```ts
type TokenizerResponse = {
  avatarFilename: string;
  tokenFilename: string;
};
(window as any).Tokenizer.launch({ name: 'actorName' }, (response: TokenizerResponse) => {
    console.log(response.avatarFilename);
    console.log(response.tokenFilename);
});
```