### PR TITLE
Add force-proxy setting

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -106,6 +106,13 @@ export function init() {
     default: "https://london.drop.mrprimate.co.uk/",
   });
 
+  game.settings.register("vtta-tokenizer", "force-proxy", {
+    scope: "world",
+    config: false,
+    type: Boolean,
+    default: false,
+  });
+
   game.settings.register("vtta-tokenizer", "paste-target", {
     scope: "world",
     config: false,


### PR DESCRIPTION
If a user hosts their own CORS proxy, they could only proxy requests to a subset of addresses (which the default proxy already handles for everyone). Changing the proxy setting was useless. 

This change allows setting your own proxy to fix cors errors as described in #26. If force-proxy setting is set (`game.settings.set("vtta-tokenizer", "force-proxy", true)`, then the proxy is applied to all full urls.

Url changes enable using https://github.com/VTTAssets/image-proxy with a custom access token auth.